### PR TITLE
Update wrapper.py

### DIFF
--- a/robosuite/wrappers/wrapper.py
+++ b/robosuite/wrappers/wrapper.py
@@ -39,9 +39,10 @@ class Wrapper:
 
     def observation_spec(self):
         return self.env.observation_spec()
-
+    
+    @property
     def action_spec(self):
-        return self.env.action_spec()
+        return self.env.action_spec
 
     @property
     def dof(self):


### PR DESCRIPTION
I believe this should be a property, because if we say first wrap the environment in ```DemoSamplerWrapper``` and then in ```GymWrapper``` it will error out saying method object is not iterable, but with the proposed change it does not error out